### PR TITLE
Generic Host and multi-targeting

### DIFF
--- a/src/BufferExtensions.cs
+++ b/src/BufferExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.Internal
+{
+	public static class BufferExtensions
+	{
+		public static ArraySegment<byte> GetArray(this Memory<byte> memory)
+		{
+			return ((ReadOnlyMemory<byte>)memory).GetArray();
+		}
+
+		public static ArraySegment<byte> GetArray(this ReadOnlyMemory<byte> memory)
+		{
+			if (!MemoryMarshal.TryGetArray(memory, out var result))
+			{
+				throw new InvalidOperationException("Buffer backed by array was expected");
+			}
+			return result;
+		}
+	}
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,131 +1,14 @@
-﻿using System;
-using System.Buffers;
-using System.IO.Pipelines;
-using System.Net;
-using System.Net.Sockets;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace TcpEcho
 {
     class Program
     {
-        static async Task Main(string[] args)
-        {
-            var listenSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
-            listenSocket.Bind(new IPEndPoint(IPAddress.Loopback, 8087));
-
-            Console.WriteLine("Listening on port 8087");
-
-            listenSocket.Listen(120);
-
-            while (true)
-            {
-                var socket = await listenSocket.AcceptAsync();
-                _ = ProcessLinesAsync(socket);
-            }
-        }
-
-        private static async Task ProcessLinesAsync(Socket socket)
-        {
-            Console.WriteLine($"[{socket.RemoteEndPoint}]: connected");
-
-            var pipe = new Pipe();
-            Task writing = FillPipeAsync(socket, pipe.Writer);
-            Task reading = ReadPipeAsync(socket, pipe.Reader);
-
-            await Task.WhenAll(reading, writing);
-
-            Console.WriteLine($"[{socket.RemoteEndPoint}]: disconnected");
-        }
-
-        private static async Task FillPipeAsync(Socket socket, PipeWriter writer)
-        {
-            const int minimumBufferSize = 512;
-
-            while (true)
-            {
-                try
-                {
-                    // Request a minimum of 512 bytes from the PipeWriter
-                    Memory<byte> memory = writer.GetMemory(minimumBufferSize);
-
-                    int bytesRead = await socket.ReceiveAsync(memory, SocketFlags.None);
-                    if (bytesRead == 0)
-                    {
-                        break;
-                    }
-
-                    // Tell the PipeWriter how much was read
-                    writer.Advance(bytesRead);
-                }
-                catch
-                {
-                    break;
-                }
-
-                // Make the data available to the PipeReader
-                FlushResult result = await writer.FlushAsync();
-
-                if (result.IsCompleted)
-                {
-                    break;
-                }
-            }
-
-            // Signal to the reader that we're done writing
-            writer.Complete();
-        }
-
-        private static async Task ReadPipeAsync(Socket socket, PipeReader reader)
-        {
-            while (true)
-            {
-                ReadResult result = await reader.ReadAsync();
-
-                ReadOnlySequence<byte> buffer = result.Buffer;
-                SequencePosition? position = null;
-
-                do
-                {
-                    // Find the EOL
-                    position = buffer.PositionOf((byte)'\n');
-
-                    if (position != null)
-                    {
-                        var line = buffer.Slice(0, position.Value);
-                        ProcessLine(socket, line);
-
-                        // This is equivalent to position + 1
-                        var next = buffer.GetPosition(1, position.Value);
-
-                        // Skip what we've already processed including \n
-                        buffer = buffer.Slice(next);
-                    }
-                }
-                while (position != null);
-
-                // We sliced the buffer until no more data could be processed
-                // Tell the PipeReader how much we consumed and how much we left to process
-                reader.AdvanceTo(buffer.Start, buffer.End);
-
-                if (result.IsCompleted)
-                {
-                    break;
-                }
-            }
-
-            reader.Complete();
-        }
-
-        private static void ProcessLine(Socket socket, in ReadOnlySequence<byte> buffer)
-        {
-            Console.Write($"[{socket.RemoteEndPoint}]: ");
-            foreach (var segment in buffer)
-            {
-                Console.Write(Encoding.UTF8.GetString(segment.Span));
-            }
-            Console.WriteLine();
-        }
+        static async Task Main()
+            => await new HostBuilder()
+            .ConfigureServices(services => services.AddHostedService<TcpEchoServer>())
+            .RunConsoleAsync();
     }
 }

--- a/src/TcpEcho.csproj
+++ b/src/TcpEcho.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net461;netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/TcpEcho.csproj
+++ b/src/TcpEcho.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,5 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.IO.Pipelines" Version="4.5.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.1" />
   </ItemGroup>
+
 </Project>

--- a/src/TcpEchoServer.cs
+++ b/src/TcpEchoServer.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace TcpEcho
+{
+    public class TcpEchoServer : BackgroundService
+    {
+        private Socket _listenSocket;
+        private volatile bool _unbinding;
+
+        public override Task StartAsync(CancellationToken cancellationToken)
+        {
+            _listenSocket = new Socket(SocketType.Stream, ProtocolType.Tcp);
+            _listenSocket.Bind(new IPEndPoint(IPAddress.Loopback, 8087));
+
+            Console.WriteLine("Listening on port 8087");
+
+            _listenSocket.Listen(120);
+
+            return base.StartAsync(cancellationToken);
+        }
+
+        public override async Task StopAsync(CancellationToken cancellationToken)
+        {
+            Console.WriteLine("Shutting down server...");
+
+            if (_listenSocket == null)
+            {
+                return;
+            }
+
+            _unbinding = true;
+            _listenSocket.Dispose();
+
+            await base.StopAsync(cancellationToken);
+
+            _unbinding = false;
+            _listenSocket = null;
+        }
+
+        protected override Task ExecuteAsync(CancellationToken stoppingToken)
+            => RunAcceptLoopAsync(stoppingToken);
+
+        private async Task RunAcceptLoopAsync(CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var socket = await _listenSocket.AcceptAsync();
+                    _ = ProcessLinesAsync(socket, stoppingToken);
+                }
+                catch (SocketException) when (_unbinding)
+                {
+                    // Eat the exception (on unbinding only).
+                }
+            }
+
+            Debug.WriteLine("Accept-loop shut down");
+        }
+
+        private async Task ProcessLinesAsync(Socket socket, CancellationToken stoppingToken)
+        {
+            Console.WriteLine($"[{socket.RemoteEndPoint}]: connected");
+
+            var pipe = new Pipe();
+            Task writing = FillPipeAsync(socket, pipe.Writer, stoppingToken);
+            Task reading = ReadPipeAsync(socket, pipe.Reader, stoppingToken);
+
+            await Task.WhenAll(reading, writing);
+
+            Console.WriteLine($"[{socket.RemoteEndPoint}]: disconnected");
+        }
+
+        private async Task FillPipeAsync(Socket socket, PipeWriter writer, CancellationToken stoppingToken)
+        {
+            const int minimumBufferSize = 512;
+
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    // Request a minimum of 512 bytes from the PipeWriter
+                    Memory<byte> memory = writer.GetMemory(minimumBufferSize);
+
+                    int bytesRead = await socket.ReceiveAsync(memory, SocketFlags.None, stoppingToken);
+                    if (bytesRead == 0)
+                    {
+                        break;
+                    }
+
+                    // Tell the PipeWriter how much was read
+                    writer.Advance(bytesRead);
+                }
+                catch
+                {
+                    break;
+                }
+
+                // Make the data available to the PipeReader
+                FlushResult result = await writer.FlushAsync(stoppingToken);
+
+                if (result.IsCompleted)
+                {
+                    break;
+                }
+            }
+
+            if (stoppingToken.IsCancellationRequested)
+            {
+                Debug.WriteLine("FillPipe shut down");
+            }
+
+            // Signal to the reader that we're done writing
+            writer.Complete();
+        }
+
+        private async Task ReadPipeAsync(Socket socket, PipeReader reader, CancellationToken stoppingToken)
+        {
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                ReadResult result = await reader.ReadAsync(stoppingToken);
+
+                ReadOnlySequence<byte> buffer = result.Buffer;
+                SequencePosition? position = null;
+
+                do
+                {
+                    // Find the EOL
+                    position = buffer.PositionOf((byte)'\n');
+
+                    if (position != null)
+                    {
+                        var line = buffer.Slice(0, position.Value);
+                        ProcessLine(socket, line);
+
+                        // This is equivalent to position + 1
+                        var next = buffer.GetPosition(1, position.Value);
+
+                        // Skip what we've already processed including \n
+                        buffer = buffer.Slice(next);
+                    }
+                }
+                while (position != null);
+
+                // We sliced the buffer until no more data could be processed
+                // Tell the PipeReader how much we consumed and how much we left to process
+                reader.AdvanceTo(buffer.Start, buffer.End);
+
+                if (result.IsCompleted)
+                {
+                    break;
+                }
+            }
+
+            if (stoppingToken.IsCancellationRequested)
+            {
+                Debug.WriteLine("ReadPipe shut down");
+            }
+
+            reader.Complete();
+        }
+
+        private void ProcessLine(Socket socket, in ReadOnlySequence<byte> buffer)
+        {
+            Console.Write($"[{socket.RemoteEndPoint}]: ");
+            foreach (var segment in buffer)
+            {
+                Console.Write(Encoding.UTF8.GetString(segment.Span));
+            }
+            Console.WriteLine();
+        }
+    }
+}


### PR DESCRIPTION
As of https://github.com/davidfowl/TcpEcho/issues/1#issuecomment-404997171

* TcpEchoServer implemented with generic host
* Multitargeting netcoreapp2.1, netstandard2.0, net461

The target for .NET Standard 2.0 doesn't make sense in an exe, but it got added due a question in #1 (now deleted), so to show that the code works also on this target.

I would appreciate to tag https://github.com/davidfowl/TcpEcho/commit/07ad4df181151850974219b8ebf434eee37778a4 (maybe with _blog-post_), so that the initial simple and plain to the point intro can be easily discovered. When seeing intros I'd like to see just the relevant parts, without noise (in the sense for the intro) disrupting it.

Fixes #1 
Fixes #2 